### PR TITLE
Redesign site as arcade-style CV — remove all non-CV sections

### DIFF
--- a/_layouts/arcade.html
+++ b/_layouts/arcade.html
@@ -1,0 +1,588 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Clément Baccar — Head of Data &amp; AI">
+  <title>{{ page.title | default: site.title }}</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+
+  <style>
+    /* ═══════════════════════════════════════════════════
+       ARCADE CV — STYLESHEET
+       ═══════════════════════════════════════════════════ */
+    :root {
+      --bg:         #080810;
+      --bg-card:    #0e0e1e;
+      --bg-card2:   #080814;
+      --neon-green: #00ff88;
+      --neon-pink:  #ff2d78;
+      --neon-cyan:  #00d4ff;
+      --neon-yellow:#ffe600;
+      --neon-purple:#bf5fff;
+      --text:       #b8c8e0;
+      --text-dim:   #556080;
+      --border-g:   rgba(0,255,136,.22);
+      --border-c:   rgba(0,212,255,.22);
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'Share Tech Mono', monospace;
+      font-size: 14px;
+      line-height: 1.6;
+      min-height: 100vh;
+      overflow-x: hidden;
+    }
+
+    /* CRT scanlines */
+    body::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background: repeating-linear-gradient(
+        0deg,
+        transparent,
+        transparent 2px,
+        rgba(0,0,0,.06) 2px,
+        rgba(0,0,0,.06) 4px
+      );
+      pointer-events: none;
+      z-index: 9999;
+    }
+
+    /* Scrollbar */
+    ::-webkit-scrollbar { width: 5px; }
+    ::-webkit-scrollbar-track { background: var(--bg); }
+    ::-webkit-scrollbar-thumb { background: var(--neon-green); border-radius: 2px; }
+    ::selection { background: var(--neon-green); color: #000; }
+
+    /* ─── LAYOUT ─── */
+    .arcade-wrap {
+      max-width: 1140px;
+      margin: 0 auto;
+      padding: 0 1.4rem 5rem;
+    }
+
+    /* ─── TITLE BAR ─── */
+    .arcade-titlebar {
+      text-align: center;
+      padding: 2.2rem 1rem 1.8rem;
+      border-bottom: 1px solid var(--border-g);
+      margin-bottom: 2rem;
+    }
+
+    .arcade-game-title {
+      font-family: 'Press Start 2P', monospace;
+      font-size: clamp(.9rem, 2.5vw, 1.5rem);
+      color: var(--neon-green);
+      text-shadow:
+        0 0  8px var(--neon-green),
+        0 0 20px var(--neon-green),
+        0 0 40px rgba(0,255,136,.4);
+      letter-spacing: .06em;
+      display: block;
+      margin-bottom: .8rem;
+    }
+
+    .arcade-insert-coin {
+      font-family: 'Press Start 2P', monospace;
+      font-size: .52rem;
+      color: var(--neon-yellow);
+      letter-spacing: .2em;
+      text-shadow: 0 0 8px var(--neon-yellow);
+      animation: blink 1.1s step-end infinite;
+    }
+
+    @keyframes blink { 0%,100%{opacity:1} 50%{opacity:0} }
+
+    /* ─── HERO ─── */
+    .cv-hero {
+      background: var(--bg-card);
+      border: 1px solid var(--neon-green);
+      box-shadow: 0 0 28px rgba(0,255,136,.12), inset 0 0 60px rgba(0,255,136,.03);
+      border-radius: 3px;
+      padding: 2rem 2.2rem;
+      margin-bottom: 1.4rem;
+      position: relative;
+      overflow: hidden;
+    }
+
+    /* pixel corners */
+    .cv-hero::before,
+    .cv-hero::after {
+      content: '';
+      position: absolute;
+      width: 10px; height: 10px;
+    }
+    .cv-hero::before { top: -1px; left: -1px;  border-top: 3px solid var(--neon-green); border-left: 3px solid var(--neon-green); }
+    .cv-hero::after  { top: -1px; right: -1px; border-top: 3px solid var(--neon-green); border-right: 3px solid var(--neon-green); }
+
+    .cv-hero-bottom-corners::before,
+    .cv-hero-bottom-corners::after {
+      content: '';
+      position: absolute;
+      width: 10px; height: 10px;
+    }
+    .cv-hero-bottom-corners::before { bottom: -1px; left: -1px;  border-bottom: 3px solid var(--neon-green); border-left: 3px solid var(--neon-green); }
+    .cv-hero-bottom-corners::after  { bottom: -1px; right: -1px; border-bottom: 3px solid var(--neon-green); border-right: 3px solid var(--neon-green); }
+
+    .player-badge {
+      position: absolute;
+      top: .7rem; right: 1rem;
+      font-family: 'Press Start 2P', monospace;
+      font-size: .5rem;
+      color: var(--neon-yellow);
+      text-shadow: 0 0 8px var(--neon-yellow);
+      animation: blink 2s step-end infinite;
+      letter-spacing: .1em;
+    }
+
+    .cv-hero-inner {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      flex-wrap: wrap;
+      gap: 1.5rem;
+    }
+
+    .cv-hero-name h1 {
+      font-family: 'Press Start 2P', monospace;
+      font-size: clamp(.9rem, 2vw, 1.4rem);
+      color: #fff;
+      text-shadow: 0 0 14px var(--neon-green), 0 0 28px rgba(0,255,136,.4);
+      margin-bottom: .55rem;
+      line-height: 1.5;
+    }
+
+    .cv-hero-tagline {
+      font-family: 'VT323', monospace;
+      font-size: 1.3rem;
+      color: var(--neon-green);
+      letter-spacing: .04em;
+    }
+
+    .cv-hero-contacts {
+      display: flex;
+      flex-direction: column;
+      gap: .5rem;
+    }
+
+    .cv-hero-contact-row {
+      display: flex;
+      align-items: center;
+      gap: .55rem;
+      font-size: .88rem;
+    }
+
+    .cv-hero-contact-row .fa {
+      color: var(--neon-green);
+      width: 14px;
+      text-align: center;
+      font-size: .8rem;
+    }
+
+    .cv-hero-contact-row a,
+    .cv-hero-contact-row span {
+      color: var(--text);
+      text-decoration: none;
+      transition: color .18s;
+    }
+
+    .cv-hero-contact-row a:hover {
+      color: var(--neon-green);
+      text-shadow: 0 0 6px var(--neon-green);
+    }
+
+    /* ─── CARDS ─── */
+    .cv-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border-g);
+      border-radius: 3px;
+      padding: 1.5rem 1.8rem;
+      margin-bottom: 1.4rem;
+      position: relative;
+      overflow: hidden;
+    }
+
+    /* top accent bar */
+    .cv-card::before {
+      content: '';
+      position: absolute;
+      top: 0; left: 0;
+      width: 100%; height: 2px;
+      background: linear-gradient(90deg, var(--neon-green), var(--neon-cyan), var(--neon-pink));
+    }
+
+    /* top-right corner notch */
+    .cv-card::after {
+      content: '';
+      position: absolute;
+      top: 0; right: 0;
+      width: 14px; height: 14px;
+      border-top: 2px solid var(--neon-cyan);
+      border-right: 2px solid var(--neon-cyan);
+    }
+
+    .cv-card h2 {
+      font-family: 'Press Start 2P', monospace;
+      font-size: .6rem;
+      color: var(--neon-cyan);
+      letter-spacing: .14em;
+      text-transform: uppercase;
+      text-shadow: 0 0 8px var(--neon-cyan);
+      margin-bottom: 1.2rem;
+      padding-bottom: .65rem;
+      border-bottom: 1px solid rgba(0,212,255,.18);
+      display: flex;
+      align-items: center;
+      gap: .6rem;
+    }
+
+    /* ─── 2-COLUMN GRID ─── */
+    .cv-grid {
+      display: grid;
+      grid-template-columns: 340px 1fr;
+      grid-template-areas: "left right";
+      gap: 1.4rem;
+      align-items: start;
+    }
+
+    .cv-grid .cv-left  { grid-area: left; }
+    .cv-grid .cv-right { grid-area: right; }
+
+    @media (max-width: 840px) {
+      .cv-grid {
+        grid-template-columns: 1fr;
+        grid-template-areas: "right" "left";
+      }
+      .cv-hero-name h1 { font-size: .85rem; }
+      .arcade-game-title { font-size: .9rem; }
+    }
+
+    /* ─── PROFILE ─── */
+    .cv-profile-text {
+      font-size: .9rem;
+      color: var(--text);
+      line-height: 1.85;
+    }
+
+    /* ─── EXPERIENCE ─── */
+    .cv-exp-item {
+      position: relative;
+      padding-left: 1.5rem;
+      margin-bottom: 2rem;
+      border-left: 2px solid rgba(0,255,136,.25);
+    }
+
+    .cv-exp-item:last-child { margin-bottom: 0; }
+
+    .cv-exp-item::before {
+      content: '▶';
+      position: absolute;
+      left: -.62rem;
+      top: .1rem;
+      color: var(--neon-green);
+      font-size: .75rem;
+      text-shadow: 0 0 8px var(--neon-green);
+      line-height: 1;
+    }
+
+    .cv-exp-role {
+      font-family: 'Press Start 2P', monospace;
+      font-size: .55rem;
+      color: #fff;
+      line-height: 1.7;
+      margin-bottom: .3rem;
+    }
+
+    .cv-exp-company {
+      font-family: 'VT323', monospace;
+      font-size: 1.3rem;
+      color: var(--neon-pink);
+      text-shadow: 0 0 6px var(--neon-pink);
+      margin-bottom: .2rem;
+    }
+
+    .cv-exp-meta {
+      font-size: .76rem;
+      color: var(--text-dim);
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+      margin-bottom: .7rem;
+    }
+
+    .cv-exp-meta .fa { margin-right: .2rem; }
+
+    .cv-exp-bullets {
+      list-style: none;
+      padding: 0;
+    }
+
+    .cv-exp-bullets li {
+      position: relative;
+      padding-left: 1.2rem;
+      font-size: .83rem;
+      color: var(--text);
+      line-height: 1.75;
+      margin-bottom: .4rem;
+    }
+
+    .cv-exp-bullets li::before {
+      content: '»';
+      position: absolute;
+      left: 0;
+      color: var(--neon-cyan);
+    }
+
+    .cv-exp-bullets li strong { color: var(--neon-cyan); }
+
+    /* ─── TECH CHIPS ─── */
+    .cv-chips-group { margin-bottom: 1rem; }
+    .cv-chips-group:last-child { margin-bottom: 0; }
+
+    .cv-chips-group-label {
+      font-family: 'Press Start 2P', monospace;
+      font-size: .42rem;
+      color: var(--neon-yellow);
+      text-shadow: 0 0 6px var(--neon-yellow);
+      letter-spacing: .08em;
+      margin-bottom: .5rem;
+    }
+
+    .cv-chips {
+      list-style: none;
+      padding: 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: .38rem;
+    }
+
+    .cv-chips li {
+      background: rgba(0,212,255,.07);
+      color: var(--neon-cyan);
+      border: 1px solid rgba(0,212,255,.3);
+      border-radius: 2px;
+      padding: .18rem .6rem;
+      font-size: .77rem;
+      font-family: 'Share Tech Mono', monospace;
+      cursor: default;
+      transition: all .18s;
+    }
+
+    .cv-chips li:hover {
+      background: rgba(0,212,255,.2);
+      box-shadow: 0 0 8px rgba(0,212,255,.45);
+      transform: translateY(-1px);
+    }
+
+    /* ─── LANGUAGE BARS ─── */
+    .cv-lang { margin-bottom: 1rem; }
+    .cv-lang:last-child { margin-bottom: 0; }
+
+    .cv-lang-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      margin-bottom: .4rem;
+    }
+
+    .cv-lang-name {
+      font-size: .88rem;
+      color: #fff;
+      font-weight: 600;
+    }
+
+    .cv-lang-level {
+      font-family: 'Press Start 2P', monospace;
+      font-size: .42rem;
+      color: var(--neon-yellow);
+    }
+
+    .cv-lang-bar {
+      height: 10px;
+      background: rgba(255,255,255,.05);
+      border: 1px solid rgba(0,255,136,.2);
+      border-radius: 2px;
+      overflow: hidden;
+      position: relative;
+    }
+
+    .cv-lang-bar-fill {
+      height: 100%;
+      background: linear-gradient(90deg, var(--neon-green), var(--neon-cyan));
+      box-shadow: 0 0 8px var(--neon-green);
+      animation: barGrow 1.4s ease-out;
+    }
+
+    /* segmented hp bar */
+    .cv-lang-bar-fill::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: repeating-linear-gradient(
+        90deg,
+        transparent,
+        transparent 9px,
+        rgba(0,0,0,.35) 9px,
+        rgba(0,0,0,.35) 10px
+      );
+    }
+
+    @keyframes barGrow { from { width: 0 !important; } }
+
+    /* ─── EDUCATION ─── */
+    .cv-edu-item {
+      padding-left: 1rem;
+      border-left: 2px solid rgba(255,45,120,.35);
+      margin-bottom: 1.1rem;
+    }
+    .cv-edu-item:last-child { margin-bottom: 0; }
+
+    .cv-edu-degree {
+      font-size: .86rem;
+      color: #fff;
+      font-weight: 600;
+      margin-bottom: .18rem;
+    }
+
+    .cv-edu-school {
+      font-family: 'VT323', monospace;
+      font-size: 1.1rem;
+      color: var(--neon-pink);
+      margin-bottom: .15rem;
+    }
+
+    .cv-edu-date {
+      font-family: 'Press Start 2P', monospace;
+      font-size: .42rem;
+      color: var(--neon-yellow);
+    }
+
+    /* ─── COMMUNITY ─── */
+    .cv-community-item {
+      padding-left: 1rem;
+      border-left: 2px solid rgba(191,95,255,.35);
+      margin-bottom: 1.1rem;
+    }
+    .cv-community-item:last-child { margin-bottom: 0; }
+
+    .cv-community-role {
+      font-size: .86rem;
+      color: #fff;
+      font-weight: 600;
+      margin-bottom: .1rem;
+    }
+
+    .cv-community-org {
+      font-family: 'VT323', monospace;
+      font-size: 1.1rem;
+      color: var(--neon-purple);
+      text-shadow: 0 0 5px var(--neon-purple);
+      margin-bottom: .1rem;
+    }
+
+    .cv-community-meta {
+      font-size: .76rem;
+      color: var(--text-dim);
+      margin-bottom: .3rem;
+    }
+
+    .cv-community-desc {
+      font-size: .83rem;
+      color: var(--text);
+      line-height: 1.6;
+    }
+
+    /* ─── CONFERENCES ─── */
+    .cv-conf-text {
+      font-size: .88rem;
+      color: var(--text);
+      line-height: 1.8;
+    }
+
+    .cv-conf-text strong { color: var(--neon-cyan); }
+
+    /* ─── DOWNLOAD BUTTON ─── */
+    .cv-download-wrap {
+      text-align: right;
+      margin-top: .6rem;
+    }
+
+    .cv-download {
+      display: inline-flex;
+      align-items: center;
+      gap: .6rem;
+      background: transparent;
+      color: var(--neon-green);
+      border: 2px solid var(--neon-green);
+      padding: .65rem 1.3rem;
+      font-family: 'Press Start 2P', monospace;
+      font-size: .5rem;
+      letter-spacing: .1em;
+      text-decoration: none;
+      transition: all .2s;
+      text-shadow: 0 0 6px var(--neon-green);
+      box-shadow: 0 0 12px rgba(0,255,136,.18), inset 0 0 12px transparent;
+    }
+
+    .cv-download:hover {
+      background: var(--neon-green);
+      color: #000;
+      text-shadow: none;
+      box-shadow: 0 0 22px rgba(0,255,136,.6);
+    }
+
+    /* ─── FOOTER ─── */
+    .arcade-footer {
+      text-align: center;
+      padding: 2rem 0 1rem;
+      border-top: 1px solid var(--border-g);
+      margin-top: 2rem;
+    }
+
+    .arcade-footer-line {
+      font-family: 'Press Start 2P', monospace;
+      font-size: .45rem;
+      color: var(--text-dim);
+      letter-spacing: .12em;
+      margin-bottom: 1rem;
+    }
+
+    .arcade-social {
+      display: flex;
+      justify-content: center;
+      gap: 1.8rem;
+    }
+
+    .arcade-social a {
+      color: var(--text-dim);
+      font-size: 1.3rem;
+      text-decoration: none;
+      transition: all .2s;
+    }
+
+    .arcade-social a:hover {
+      color: var(--neon-green);
+      text-shadow: 0 0 10px var(--neon-green);
+    }
+  </style>
+</head>
+<body>
+  {{ content }}
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,8 +1,293 @@
 ---
-layout: default
-title: Home
+layout: arcade
+title: Clément Baccar · CV
 ---
 
-{% include thumbnails.html %}
+<div class="arcade-wrap">
 
-{% include footer.html %}
+  <!-- ════════════════════════════════════
+       TITLE BAR
+  ════════════════════════════════════ -->
+  <header class="arcade-titlebar">
+    <span class="arcade-game-title">CLÉMENT BACCAR</span>
+    <span class="arcade-insert-coin">▶ CV.EXE — INSERT COIN TO CONTINUE ◀</span>
+  </header>
+
+  <!-- ════════════════════════════════════
+       PLAYER 1 — HERO CARD
+  ════════════════════════════════════ -->
+  <div class="cv-hero cv-hero-bottom-corners">
+    <span class="player-badge">★ PLAYER 1 ★</span>
+    <div class="cv-hero-inner">
+      <div class="cv-hero-name">
+        <h1>CLÉMENT<br>BACCAR</h1>
+        <p class="cv-hero-tagline">HEAD OF DATA &amp; AI · AI TRAINER · DATA LEADER</p>
+      </div>
+      <div class="cv-hero-contacts">
+        <div class="cv-hero-contact-row">
+          <i class="fa fa-envelope"></i>
+          <a href="mailto:baccar.clement@gmail.com">baccar.clement@gmail.com</a>
+        </div>
+        <div class="cv-hero-contact-row">
+          <i class="fa fa-phone"></i>
+          <a href="tel:+33607960463">+33 6 07 96 04 63</a>
+        </div>
+        <div class="cv-hero-contact-row">
+          <i class="fa fa-map-marker"></i>
+          <span>Paris, France</span>
+        </div>
+        <div class="cv-hero-contact-row">
+          <i class="fa fa-linkedin"></i>
+          <a href="https://www.linkedin.com/in/clement-baccar-a23b6768/" target="_blank" rel="noopener">
+            linkedin/clement-baccar
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ════════════════════════════════════
+       CHARACTER BIO
+  ════════════════════════════════════ -->
+  <div class="cv-card">
+    <h2><i class="fa fa-user"></i>// CHARACTER BIO</h2>
+    <p class="cv-profile-text">
+      Dual-track Data and AI leader combining deep technical expertise in MLOps, DataOps and GenAI
+      with executive strategy. Track record of building high-performing full-stack teams, driving
+      significant revenue generation through AI product innovation, and executing large-scale
+      modernisation of data architectures.
+    </p>
+  </div>
+
+  <!-- ════════════════════════════════════
+       2-COLUMN GRID
+  ════════════════════════════════════ -->
+  <div class="cv-grid">
+
+    <!-- ══ RIGHT — most important content ══ -->
+    <div class="cv-right">
+
+      <!-- ─── QUEST LOG / EXPERIENCE ─── -->
+      <div class="cv-card">
+        <h2><i class="fa fa-briefcase"></i>// QUEST LOG</h2>
+
+        <div class="cv-exp-item">
+          <p class="cv-exp-role">HEAD OF DATA &amp; AI</p>
+          <p class="cv-exp-company">Brut.</p>
+          <div class="cv-exp-meta">
+            <span><i class="fa fa-calendar"></i> April 2022 – Present</span>
+            <span><i class="fa fa-map-marker"></i> Paris, France</span>
+          </div>
+          <ul class="cv-exp-bullets">
+            <li><strong>Management &amp; Leadership:</strong> Recruited and managed an 8-person full-stack Data team (Data Engineers, Analysts, ML Engineers), fostering a product culture and full technical autonomy.</li>
+            <li><strong>Business &amp; Revenue:</strong> Generated +200k€ in new revenue streams within months by developing commercial offers based on Generative AI.</li>
+            <li><strong>GenAI Strategy &amp; Adoption:</strong> Deployed a global GenAI strategy for 200 employees across 3 continents, achieving a &gt;80% adoption rate.</li>
+            <li><strong>Innovation &amp; Product:</strong> Designed and deployed 5 major GenAI projects into production, transforming content creation and analysis.</li>
+            <li><strong>Infrastructure &amp; Reliability:</strong> Built a unified Analytics platform integrating 10+ data sources with continuous collection ensuring a &gt;95% SLA.</li>
+          </ul>
+        </div>
+
+        <div class="cv-exp-item">
+          <p class="cv-exp-role">AI TRAINER</p>
+          <p class="cv-exp-company">Pollen</p>
+          <div class="cv-exp-meta">
+            <span><i class="fa fa-calendar"></i> June 2023 – Present</span>
+            <span><i class="fa fa-map-marker"></i> France</span>
+          </div>
+          <ul class="cv-exp-bullets">
+            <li>Trained 200+ professionals on Generative AI across various organisations.</li>
+          </ul>
+        </div>
+
+        <div class="cv-exp-item">
+          <p class="cv-exp-role">HEAD OF DATA &amp; ML ENGINEERING</p>
+          <p class="cv-exp-company">namR</p>
+          <div class="cv-exp-meta">
+            <span><i class="fa fa-calendar"></i> Dec 2018 – April 2022</span>
+            <span><i class="fa fa-map-marker"></i> Paris, France</span>
+          </div>
+          <ul class="cv-exp-bullets">
+            <li><strong>Deep Learning &amp; Scale:</strong> Developed and industrialised a Deep Learning inference platform processing 34M+ aerial images for French building characterisation.</li>
+            <li><strong>Transformation &amp; Modern Data Stack:</strong> Led strategic migration of 500+ tables and workflows from legacy systems to a "Code-First" architecture (Airflow), integrating MLOps and Data Quality standards.</li>
+            <li><strong>Team Management:</strong> Grew and structured the team to 10 Data Engineers, managing full-cycle recruitment, career paths, and technical upskilling.</li>
+            <li><strong>Architecture:</strong> Designed automated ingestion pipelines for Open Data, reducing technical debt and accelerating update cycles.</li>
+          </ul>
+        </div>
+
+        <div class="cv-exp-item">
+          <p class="cv-exp-role">MACHINE LEARNING ENGINEER</p>
+          <p class="cv-exp-company">Saegus</p>
+          <div class="cv-exp-meta">
+            <span><i class="fa fa-calendar"></i> Feb 2016 – Nov 2018</span>
+            <span><i class="fa fa-map-marker"></i> Paris, France</span>
+          </div>
+          <ul class="cv-exp-bullets">
+            <li>Machine learning engineer focused on customer insight and data-driven product development.</li>
+          </ul>
+        </div>
+
+        <div class="cv-exp-item">
+          <p class="cv-exp-role">ML ENGINEER — CUSTOMER INSIGHT</p>
+          <p class="cv-exp-company">Air France</p>
+          <div class="cv-exp-meta">
+            <span><i class="fa fa-calendar"></i> Oct 2014 – Oct 2015</span>
+            <span><i class="fa fa-map-marker"></i> Paris, France</span>
+          </div>
+        </div>
+
+      </div><!-- /quest log -->
+
+      <!-- ─── ACHIEVEMENTS / CONFERENCES ─── -->
+      <div class="cv-card">
+        <h2><i class="fa fa-microphone"></i>// ACHIEVEMENTS UNLOCKED</h2>
+        <p class="cv-conf-text">
+          Speaker at various tech events and guest on podcasts discussing <strong>Data Strategy</strong>,
+          <strong>Generative AI</strong> and <strong>MLOps</strong>. Topics cover GenAI adoption in the enterprise,
+          modern data architectures, and lessons from building data teams at scale.
+        </p>
+      </div>
+
+      <!-- ─── DOWNLOAD ─── -->
+      <div class="cv-download-wrap">
+        <a href="/pages/cv_baccar_clement.pdf" class="cv-download" download>
+          <i class="fa fa-download"></i> DOWNLOAD.PDF
+        </a>
+      </div>
+
+    </div><!-- /right -->
+
+    <!-- ══ LEFT — supporting content ══ -->
+    <div class="cv-left">
+
+      <!-- ─── INVENTORY / TECH STACK ─── -->
+      <div class="cv-card">
+        <h2><i class="fa fa-code"></i>// INVENTORY</h2>
+
+        <div class="cv-chips-group">
+          <p class="cv-chips-group-label">◆ Languages &amp; Core</p>
+          <ul class="cv-chips">
+            <li>Python</li><li>SQL</li><li>Pandas</li>
+          </ul>
+        </div>
+
+        <div class="cv-chips-group">
+          <p class="cv-chips-group-label">◆ ML &amp; GenAI</p>
+          <ul class="cv-chips">
+            <li>PyTorch</li><li>scikit-learn</li><li>LangChain</li><li>DVC</li>
+          </ul>
+        </div>
+
+        <div class="cv-chips-group">
+          <p class="cv-chips-group-label">◆ Data Eng &amp; DBs</p>
+          <ul class="cv-chips">
+            <li>PostgreSQL</li><li>Elastic</li><li>BigQuery</li><li>Neo4j</li>
+            <li>Airflow</li><li>Prefect</li><li>Dataiku</li><li>dbt</li>
+          </ul>
+        </div>
+
+        <div class="cv-chips-group">
+          <p class="cv-chips-group-label">◆ Cloud &amp; Infra</p>
+          <ul class="cv-chips">
+            <li>GCP</li><li>Scaleway</li><li>OVH</li>
+            <li>Terraform</li><li>Cloudbuild</li><li>GitLab CI</li>
+          </ul>
+        </div>
+
+        <div class="cv-chips-group">
+          <p class="cv-chips-group-label">◆ API &amp; Dev</p>
+          <ul class="cv-chips">
+            <li>Flask</li><li>FastAPI</li><li>GitHub</li><li>GitLab</li>
+          </ul>
+        </div>
+
+        <div class="cv-chips-group">
+          <p class="cv-chips-group-label">◆ Geospatial</p>
+          <ul class="cv-chips">
+            <li>PostGIS</li><li>Rasterio</li><li>BigQuery GIS</li>
+            <li>pgRouting</li><li>QGIS</li>
+          </ul>
+        </div>
+      </div><!-- /inventory -->
+
+      <!-- ─── TRAINING ARC / EDUCATION ─── -->
+      <div class="cv-card">
+        <h2><i class="fa fa-graduation-cap"></i>// TRAINING ARC</h2>
+
+        <div class="cv-edu-item">
+          <p class="cv-edu-degree">Advanced Master, IT Management (Joint Degree)</p>
+          <p class="cv-edu-school">ESSEC &amp; Telecom ParisTech</p>
+          <p class="cv-edu-date">2015 – 2016</p>
+        </div>
+
+        <div class="cv-edu-item">
+          <p class="cv-edu-degree">Master 2 Data Science, Econometrics, ML</p>
+          <p class="cv-edu-school">Panthéon-Sorbonne (Paris I)</p>
+          <p class="cv-edu-date">2014 – 2015</p>
+        </div>
+      </div><!-- /education -->
+
+      <!-- ─── LANGUAGES UNLOCKED ─── -->
+      <div class="cv-card">
+        <h2><i class="fa fa-globe"></i>// LANGUAGES UNLOCKED</h2>
+
+        <div class="cv-lang">
+          <div class="cv-lang-header">
+            <span class="cv-lang-name">French</span>
+            <span class="cv-lang-level">NATIVE</span>
+          </div>
+          <div class="cv-lang-bar"><div class="cv-lang-bar-fill" style="width:100%"></div></div>
+        </div>
+
+        <div class="cv-lang">
+          <div class="cv-lang-header">
+            <span class="cv-lang-name">English</span>
+            <span class="cv-lang-level">PROFESSIONAL</span>
+          </div>
+          <div class="cv-lang-bar"><div class="cv-lang-bar-fill" style="width:85%"></div></div>
+        </div>
+      </div><!-- /languages -->
+
+      <!-- ─── GUILD MEMBERSHIPS ─── -->
+      <div class="cv-card">
+        <h2><i class="fa fa-users"></i>// GUILD MEMBERSHIPS</h2>
+
+        <div class="cv-community-item">
+          <p class="cv-community-role">Member (Core)</p>
+          <p class="cv-community-org">Tech.Rocks</p>
+          <p class="cv-community-meta"><i class="fa fa-calendar"></i> Nov 2024 – Present &nbsp;·&nbsp; France</p>
+          <p class="cv-community-desc">Network of tech leaders in France.</p>
+        </div>
+
+        <div class="cv-community-item">
+          <p class="cv-community-role">Data Architect Advisor</p>
+          <p class="cv-community-org">The Future Society – Project AIM</p>
+          <p class="cv-community-meta"><i class="fa fa-calendar"></i> Jan 2021 – July 2022 &nbsp;·&nbsp; Remote</p>
+          <p class="cv-community-desc">Think tank incubated at Harvard Kennedy School on AI governance.</p>
+        </div>
+
+        <div class="cv-community-item">
+          <p class="cv-community-role">GIS Engineer (Volunteer)</p>
+          <p class="cv-community-org">SurfRider – Plastic Origin</p>
+          <p class="cv-community-meta"><i class="fa fa-calendar"></i> Mar 2020 – Dec 2021 &nbsp;·&nbsp; Remote</p>
+          <p class="cv-community-desc">Mapping European riverine plastic pollution using GIS and computer vision.</p>
+        </div>
+      </div><!-- /guild -->
+
+    </div><!-- /left -->
+
+  </div><!-- /cv-grid -->
+
+  <!-- ════════════════════════════════════
+       FOOTER
+  ════════════════════════════════════ -->
+  <footer class="arcade-footer">
+    <div class="arcade-footer-line">© 2024 CLÉMENT BACCAR &nbsp;·&nbsp; GAME OVER &nbsp;·&nbsp; CONTINUE?</div>
+    <div class="arcade-social">
+      <a href="https://twitter.com/baccarclement"  title="Twitter" ><i class="fa fa-twitter"></i></a>
+      <a href="https://github.com/clembac"         title="GitHub"  ><i class="fa fa-github"></i></a>
+      <a href="https://www.linkedin.com/in/clement-baccar-a23b6768/" title="LinkedIn" target="_blank" rel="noopener"><i class="fa fa-linkedin"></i></a>
+      <a href="mailto:baccar.clement@gmail.com"    title="Email"   ><i class="fa fa-envelope"></i></a>
+    </div>
+  </footer>
+
+</div><!-- /arcade-wrap -->


### PR DESCRIPTION
- Replace index.html with a full arcade/retro-game themed CV page
- Add _layouts/arcade.html: standalone dark neon layout (Press Start 2P,
  VT323, Share Tech Mono fonts; CRT scanlines; neon glow effects)
- Remove projects/about/blog/contact from the landing page; CV is now
  the sole purpose of the site
- Section order (most→least important): Hero → Character Bio →
  Quest Log (experience) → Inventory (tech stack) → Training Arc
  (education) → Languages Unlocked → Guild Memberships → Achievements
- Responsive: desktop two-column grid (skills left, experience right);
  mobile single-column with experience first
- Colour palette: dark bg #080810, neon green #00ff88, cyan #00d4ff,
  pink #ff2d78, yellow #ffe600

https://claude.ai/code/session_018ZYvcWwi5byMRjSf1erZWR